### PR TITLE
Remove `NegotiateAppVersion`

### DIFF
--- a/router/module.go
+++ b/router/module.go
@@ -15,17 +15,17 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
-	"github.com/gorilla/mux"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/spf13/cobra"
-	abci "github.com/tendermint/tendermint/abci/types"
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	porttypes "github.com/cosmos/ibc-go/v3/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v3/modules/core/exported"
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
 	"github.com/strangelove-ventures/packet-forward-middleware/router/client/cli"
 	"github.com/strangelove-ventures/packet-forward-middleware/router/keeper"
 	"github.com/strangelove-ventures/packet-forward-middleware/router/types"
+	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 var (
@@ -271,20 +271,8 @@ func (am AppModule) OnAcknowledgementPacket(ctx sdk.Context, packet channeltypes
 }
 
 // OnTimeoutPacket implements the IBCModule interface
-func (am AppModule) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress)  error {
+func (am AppModule) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Packet, relayer sdk.AccAddress) error {
 	return am.app.OnTimeoutPacket(ctx, packet, relayer)
-}
-
-// NegotiateAppVersion implements the IBCModue interface
-func (am AppModule) NegotiateAppVersion(
-	ctx sdk.Context,
-	order channeltypes.Order,
-	connectionID string,
-	portID string,
-	counterparty channeltypes.Counterparty,
-	proposedVersion string,
-) (string, error) {
-	return am.app.NegotiateAppVersion(ctx, order, connectionID, portID, counterparty, proposedVersion)
 }
 
 // For now this assumes one hop, should be better parsing


### PR DESCRIPTION
`NegotiateAppVersion` is no longer used in the migration from ibc-go v2 to v3 so we need to pull this out