### PR TITLE
fixed packet timeout timestamp bug

### DIFF
--- a/router/keeper/keeper.go
+++ b/router/keeper/keeper.go
@@ -83,7 +83,7 @@ func (k Keeper) ForwardTransferPacket(ctx sdk.Context, parsedReceiver *parser.Pa
 		parsedReceiver.HostAccAddr,
 		parsedReceiver.Destination,
 		DefaultTransferPacketTimeoutHeight,
-		DefaultTransferPacketTimeoutTimestamp,
+		DefaultTransferPacketTimeoutTimestamp+uint64(ctx.BlockTime().UnixNano()),
 	)
 	if err != nil {
 		return sdkerrors.Wrapf(sdkerrors.ErrInsufficientFunds, err.Error())

--- a/router/module_test.go
+++ b/router/module_test.go
@@ -181,7 +181,7 @@ func TestOnRecvPacket_ForwardNoFee(t *testing.T) {
 			hostAddrAcc,
 			destAddr,
 			keeper.DefaultTransferPacketTimeoutHeight,
-			keeper.DefaultTransferPacketTimeoutTimestamp,
+			keeper.DefaultTransferPacketTimeoutTimestamp+uint64(ctx.BlockTime().UnixNano()),
 		).Return(nil),
 	)
 
@@ -238,7 +238,7 @@ func TestOnRecvPacket_ForwardWithFee(t *testing.T) {
 			hostAccAddr,
 			destAddr,
 			keeper.DefaultTransferPacketTimeoutHeight,
-			keeper.DefaultTransferPacketTimeoutTimestamp,
+			keeper.DefaultTransferPacketTimeoutTimestamp+uint64(ctx.BlockTime().UnixNano()),
 		).Return(nil),
 	)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD014 MD033 MD034 MD036 MD041 -->

## Description

This PR fixes the value of packet timeout timestamp. This bug is introduced in PR #20. This code is consistent with the code prior to that. The timeout timestamp should be the timeout duration plus the current time.

## Checklist

- [x] I have made sure the upstream branch for this PR is correct
- [x] I have made sure this PR is ready to merge
- [x] I have made sure that I have assigned reviewers related to this project
