### PR TITLE
Internal flags

### DIFF
--- a/router/ibc_middleware.go
+++ b/router/ibc_middleware.go
@@ -149,9 +149,10 @@ func (im IBCMiddleware) OnRecvPacket(
 	metadata := m.Forward
 
 	var processed, nonrefundable, disableDenomComposition bool
-	p := ctx.Context().Value("processed")
-	nr := ctx.Context().Value("nonrefundable")
-	ddc := ctx.Context().Value("disableDenomComposition")
+	goCtx := ctx.Context()
+	p := goCtx.Value("processed")
+	nr := goCtx.Value("nonrefundable")
+	ddc := goCtx.Value("disableDenomComposition")
 
 	if p != nil {
 		if pb, ok := p.(bool); ok {

--- a/router/ibc_middleware.go
+++ b/router/ibc_middleware.go
@@ -150,9 +150,9 @@ func (im IBCMiddleware) OnRecvPacket(
 
 	var processed, nonrefundable, disableDenomComposition bool
 	goCtx := ctx.Context()
-	p := goCtx.Value("processed")
-	nr := goCtx.Value("nonrefundable")
-	ddc := goCtx.Value("disableDenomComposition")
+	p := goCtx.Value(types.ProcessedKey{})
+	nr := goCtx.Value(types.NonrefundableKey{})
+	ddc := goCtx.Value(types.DisableDenomCompositionKey{})
 
 	if p != nil {
 		if pb, ok := p.(bool); ok {

--- a/router/ibc_middleware.go
+++ b/router/ibc_middleware.go
@@ -148,6 +148,27 @@ func (im IBCMiddleware) OnRecvPacket(
 
 	metadata := m.Forward
 
+	var processed, nonrefundable, disableDenomComposition bool
+	p := ctx.Context().Value("processed")
+	nr := ctx.Context().Value("nonrefundable")
+	ddc := ctx.Context().Value("disableDenomComposition")
+
+	if p != nil {
+		if pb, ok := p.(bool); ok {
+			processed = pb
+		}
+	}
+	if nr != nil {
+		if nrb, ok := p.(bool); ok {
+			nonrefundable = nrb
+		}
+	}
+	if ddc != nil {
+		if ddcb, ok := p.(bool); ok {
+			disableDenomComposition = ddcb
+		}
+	}
+
 	if err := metadata.Validate(); err != nil {
 		return channeltypes.NewErrorAcknowledgement(err.Error())
 	}
@@ -155,7 +176,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	// if this packet has been handled by another middleware in the stack there may be no need to call into the
 	// underlying app, otherwise the transfer module's OnRecvPacket callback could be invoked more than once
 	// which would mint/burn vouchers more than once
-	if !metadata.Processed {
+	if !processed {
 		ack := im.app.OnRecvPacket(ctx, packet, relayer)
 		if ack == nil || !ack.Success() {
 			return ack
@@ -165,7 +186,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	// if this packet's token denom is already the base denom for some native token on this chain,
 	// we do not need to do any further composition of the denom before forwarding the packet
 	denomOnThisChain := data.Denom
-	if !metadata.DisableDenomComposition {
+	if !disableDenomComposition {
 		denomOnThisChain = getDenomForThisChain(
 			packet.DestinationPort, packet.DestinationChannel,
 			packet.SourcePort, packet.SourceChannel,
@@ -194,7 +215,7 @@ func (im IBCMiddleware) OnRecvPacket(
 		retries = im.retriesOnTimeout
 	}
 
-	err = im.keeper.ForwardTransferPacket(ctx, nil, packet, data.Sender, data.Receiver, metadata, token, retries, timeout, []metrics.Label{})
+	err = im.keeper.ForwardTransferPacket(ctx, nil, packet, data.Sender, data.Receiver, metadata, token, retries, timeout, []metrics.Label{}, nonrefundable)
 	if err != nil {
 		return channeltypes.NewErrorAcknowledgement(err.Error())
 	}

--- a/router/keeper/keeper.go
+++ b/router/keeper/keeper.go
@@ -209,6 +209,7 @@ func (k Keeper) ForwardTransferPacket(
 	maxRetries uint8,
 	timeout time.Duration,
 	labels []metrics.Label,
+	nonrefundable bool,
 ) error {
 	var err error
 	feeAmount := sdk.NewDecFromInt(token.Amount).Mul(k.GetFeePercentage(ctx)).RoundInt()
@@ -286,7 +287,7 @@ func (k Keeper) ForwardTransferPacket(
 
 			RetriesRemaining: int32(maxRetries),
 			Timeout:          uint64(timeout.Nanoseconds()),
-			Nonrefundable:    metadata.Nonrefundable,
+			Nonrefundable:    nonrefundable,
 		}
 	} else {
 		inFlightPacket.RetriesRemaining--
@@ -389,6 +390,7 @@ func (k Keeper) RetryTimeout(
 		uint8(inFlightPacket.RetriesRemaining),
 		time.Duration(inFlightPacket.Timeout)*time.Nanosecond,
 		nil,
+		inFlightPacket.Nonrefundable,
 	)
 }
 

--- a/router/types/forward.go
+++ b/router/types/forward.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cosmos/ibc-go/v3/modules/core/24-host"
+	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 )
 
 type PacketMetadata struct {
@@ -12,15 +12,12 @@ type PacketMetadata struct {
 }
 
 type ForwardMetadata struct {
-	Receiver                string        `json:"receiver,omitempty"`
-	Port                    string        `json:"port,omitempty"`
-	Channel                 string        `json:"channel,omitempty"`
-	Timeout                 time.Duration `json:"timeout,omitempty"`
-	Retries                 *uint8        `json:"retries,omitempty"`
-	Nonrefundable           bool          `json:"nonrefundable,omitempty"`
-	Processed               bool          `json:"processed,omitempty"`
-	DisableDenomComposition bool          `json:"disable_denom_composition,omitempty"`
-	Next                    *string       `json:"next,omitempty"`
+	Receiver string        `json:"receiver,omitempty"`
+	Port     string        `json:"port,omitempty"`
+	Channel  string        `json:"channel,omitempty"`
+	Timeout  time.Duration `json:"timeout,omitempty"`
+	Retries  *uint8        `json:"retries,omitempty"`
+	Next     *string       `json:"next,omitempty"`
 }
 
 func (m *ForwardMetadata) Validate() error {

--- a/router/types/keys.go
+++ b/router/types/keys.go
@@ -16,6 +16,10 @@ const (
 	QuerierRoute = ModuleName
 )
 
+type NonrefundableKey struct{}
+type DisableDenomCompositionKey struct{}
+type ProcessedKey struct{}
+
 func RefundPacketKey(channelID, portID string, sequence uint64) []byte {
 	return []byte(fmt.Sprintf("%s/%s/%d", channelID, portID, sequence))
 }


### PR DESCRIPTION
Use context values for passing internal flags between middlewares

This eliminates the possibility of a user setting these fields in the memo, creating extra edge cases we would need to test.