### PR TITLE
Rename to old module name

### DIFF
--- a/router/types/keys.go
+++ b/router/types/keys.go
@@ -4,7 +4,7 @@ import fmt "fmt"
 
 const (
 	// ModuleName defines the 29-fee name
-	ModuleName = "packetforwardmiddleware"
+	ModuleName = "packetfowardmiddleware"
 
 	// StoreKey is the store key string for IBC transfer
 	StoreKey = ModuleName


### PR DESCRIPTION
The app module was renamed from `packetfowardmiddleware` to `packetforwardmiddleware` in `v3` to fix the spelling error.

This caused a panic for `gaia` when pruning after updating from `v7` to `v8`:

```
E[2023-01-12|20:53:14.956] Store: packetforwardmiddleware               
E[2023-01-12|20:53:14.956] Error deleting versions: cannot delete latest saved version (1) 
E[2023-01-12|20:53:14.956] Pruning height 0: 40                         
E[2023-01-12|20:53:14.956] Pruning height 1: 41                         
E[2023-01-12|20:53:14.956] Pruning height 2: 42                         
E[2023-01-12|20:53:14.956] Pruning height 3: 43                         
E[2023-01-12|20:53:14.956] Pruning height 4: 44                         
E[2023-01-12|20:53:14.956] Pruning height 5: 45                         
E[2023-01-12|20:53:14.956] Pruning height 6: 46                         
E[2023-01-12|20:53:14.956] Pruning height 7: 47                         
E[2023-01-12|20:53:14.956] Pruning height 8: 48                         
E[2023-01-12|20:53:14.956] Pruning height 9: 49                         
8:53PM ERR CONSENSUS FAILURE!!! err="cannot delete latest saved version (1)" module=consensus stack="goroutine 145 [running]:\nruntime/debug.Stack()\n\truntime/debug/stack.go:24 +0x65\ngithub.com/tendermint/tendermint/consensus.(*State).receiveRoutine.func2()\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:724 +0x4c\npanic({0x1a35380, 0xc00400ce40})\n\truntime/panic.go:884 +0x212\ngithub.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).PruneStores(0xc001038410, 0x1, {0x0?, 0x0?, 0x0?})\n\tgithub.com/cosmos/cosmos-sdk@v0.45.12-0.20230111125903-4163a1a01572/store/rootmulti/store.go:476 +0x745\ngithub.com/cosmos/cosmos-sdk/store/rootmulti.(*Store).Commit(0xc001038410)\n\tgithub.com/cosmos/cosmos-sdk@v0.45.12-0.20230111125903-4163a1a01572/store/rootmulti/store.go:432 +0x1f9\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Commit(0xc000d84e00)\n\tgithub.com/cosmos/cosmos-sdk@v0.45.12-0.20230111125903-4163a1a01572/baseapp/abci.go:314 +0x1e9\ngithub.com/tendermint/tendermint/abci/client.(*localClient).CommitSync(0xc00051be60)\n\tgithub.com/tendermint/tendermint@v0.34.24/abci/client/local_client.go:264 +0xb6\ngithub.com/tendermint/tendermint/proxy.(*appConnConsensus).CommitSync(0xc003fac4c0?)\n\tgithub.com/tendermint/tendermint@v0.34.24/proxy/app_conn.go:93 +0x22\ngithub.com/tendermint/tendermint/state.(*BlockExecutor).Commit(_, {{{0xb, 0x0}, {0xc00012fe20, 0x8}}, {0xc00012fe28, 0x6}, 0x1, 0x46, {{0xc003aee6e0, ...}, ...}, ...}, ...)\n\tgithub.com/tendermint/tendermint@v0.34.24/state/execution.go:228 +0x269\ngithub.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x0}, {0xc00012fe20, 0x8}}, {0xc00012fe28, 0x6}, 0x1, 0x46, {{0xc003aee6e0, ...}, ...}, ...}, ...)\n\tgithub.com/tendermint/tendermint@v0.34.24/state/execution.go:180 +0x6ee\ngithub.com/tendermint/tendermint/consensus.(*State).finalizeCommit(0xc0014ec000, 0x46)\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:1654 +0xafd\ngithub.com/tendermint/tendermint/consensus.(*State).tryFinalizeCommit(0xc0014ec000, 0x46)\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:1563 +0x2ff\ngithub.com/tendermint/tendermint/consensus.(*State).enterCommit.func1()\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:1498 +0x94\ngithub.com/tendermint/tendermint/consensus.(*State).enterCommit(0xc0014ec000, 0x46, 0x0)\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:1536 +0xccf\ngithub.com/tendermint/tendermint/consensus.(*State).addVote(0xc0014ec000, 0xc003aa35e0, {0xc00055c1b0, 0x28})\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:2150 +0x18dc\ngithub.com/tendermint/tendermint/consensus.(*State).tryAddVote(0xc0014ec000, 0xc003aa35e0, {0xc00055c1b0?, 0xc003abc600?})\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:1948 +0x2c\ngithub.com/tendermint/tendermint/consensus.(*State).handleMsg(0xc0014ec000, {{0x254bca0?, 0xc003a96200?}, {0xc00055c1b0?, 0x0?}})\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:853 +0x170\ngithub.com/tendermint/tendermint/consensus.(*State).receiveRoutine(0xc0014ec000, 0x0)\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:760 +0x3f9\ncreated by github.com/tendermint/tendermint/consensus.(*State).OnStart\n\tgithub.com/tendermint/tendermint@v0.34.24/consensus/state.go:379 +0x12d\n"
```

Renaming back to the old module version resolves this issue.