### PR TITLE
SetTransferKeeper

### DIFF
--- a/router/ibc_middleware.go
+++ b/router/ibc_middleware.go
@@ -24,7 +24,7 @@ var _ porttypes.Middleware = &IBCMiddleware{}
 // forward keeper and the underlying application.
 type IBCMiddleware struct {
 	app    porttypes.IBCModule
-	keeper keeper.Keeper
+	keeper *keeper.Keeper
 
 	retriesOnTimeout uint8
 	forwardTimeout   time.Duration
@@ -34,7 +34,7 @@ type IBCMiddleware struct {
 // NewIBCMiddleware creates a new IBCMiddleware given the keeper and underlying application.
 func NewIBCMiddleware(
 	app porttypes.IBCModule,
-	k keeper.Keeper,
+	k *keeper.Keeper,
 	retriesOnTimeout uint8,
 	forwardTimeout time.Duration,
 	refundTimeout time.Duration,

--- a/router/keeper/keeper.go
+++ b/router/keeper/keeper.go
@@ -27,8 +27,8 @@ import (
 // Middleware must implement types.ChannelKeeper and types.PortKeeper, expected interfaces
 // so that it can wrap IBC channel and port logic for underlying application.
 var (
-	_ types.ChannelKeeper = Keeper{}
-	_ types.PortKeeper    = Keeper{}
+	_ types.ChannelKeeper = &Keeper{}
+	_ types.PortKeeper    = &Keeper{}
 )
 
 var (
@@ -70,13 +70,13 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	portKeeper types.PortKeeper,
 	ics4Wrapper porttypes.ICS4Wrapper,
-) Keeper {
+) *Keeper {
 	// set KeyTable if it has not already been set
 	if !paramSpace.HasKeyTable() {
 		paramSpace = paramSpace.WithKeyTable(types.ParamKeyTable())
 	}
 
-	return Keeper{
+	return &Keeper{
 		cdc:        cdc,
 		storeKey:   key,
 		paramSpace: paramSpace,
@@ -90,12 +90,17 @@ func NewKeeper(
 	}
 }
 
+// SetTransferKeeper sets the transferKeeper
+func (k *Keeper) SetTransferKeeper(transferKeeper types.TransferKeeper) {
+	k.transferKeeper = transferKeeper
+}
+
 // Logger returns a module-specific logger.
-func (k Keeper) Logger(ctx sdk.Context) log.Logger {
+func (k *Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", "x/"+host.ModuleName+"-"+types.ModuleName)
 }
 
-func (k Keeper) WriteAcknowledgementForForwardedPacket(
+func (k *Keeper) WriteAcknowledgementForForwardedPacket(
 	ctx sdk.Context,
 	packet channeltypes.Packet,
 	data transfertypes.FungibleTokenPacketData,
@@ -198,7 +203,7 @@ func (k Keeper) WriteAcknowledgementForForwardedPacket(
 	}, ack)
 }
 
-func (k Keeper) ForwardTransferPacket(
+func (k *Keeper) ForwardTransferPacket(
 	ctx sdk.Context,
 	inFlightPacket *types.InFlightPacket,
 	srcPacket channeltypes.Packet,
@@ -315,7 +320,7 @@ func (k Keeper) ForwardTransferPacket(
 }
 
 // TimeoutShouldRetry returns inFlightPacket and no error if retry should be attempted. Error is returned if IBC refund should occur.
-func (k Keeper) TimeoutShouldRetry(
+func (k *Keeper) TimeoutShouldRetry(
 	ctx sdk.Context,
 	packet channeltypes.Packet,
 ) (*types.InFlightPacket, error) {
@@ -345,7 +350,7 @@ func (k Keeper) TimeoutShouldRetry(
 	return &inFlightPacket, nil
 }
 
-func (k Keeper) RetryTimeout(
+func (k *Keeper) RetryTimeout(
 	ctx sdk.Context,
 	channel, port string,
 	data transfertypes.FungibleTokenPacketData,
@@ -394,7 +399,7 @@ func (k Keeper) RetryTimeout(
 	)
 }
 
-func (k Keeper) RemoveInFlightPacket(ctx sdk.Context, packet channeltypes.Packet) {
+func (k *Keeper) RemoveInFlightPacket(ctx sdk.Context, packet channeltypes.Packet) {
 	store := ctx.KVStore(k.storeKey)
 	key := types.RefundPacketKey(packet.SourceChannel, packet.SourcePort, packet.Sequence)
 	if !store.Has(key) {
@@ -407,7 +412,7 @@ func (k Keeper) RemoveInFlightPacket(ctx sdk.Context, packet channeltypes.Packet
 }
 
 // GetAndClearInFlightPacket will fetch an InFlightPacket from the store, remove it if it exists, and return it.
-func (k Keeper) GetAndClearInFlightPacket(
+func (k *Keeper) GetAndClearInFlightPacket(
 	ctx sdk.Context,
 	channel string,
 	port string,
@@ -432,37 +437,37 @@ func (k Keeper) GetAndClearInFlightPacket(
 
 // BindPort defines a wrapper function for the port Keeper's function in
 // order to expose it to module's InitGenesis function.
-func (k Keeper) BindPort(ctx sdk.Context, portID string) *capabilitytypes.Capability {
+func (k *Keeper) BindPort(ctx sdk.Context, portID string) *capabilitytypes.Capability {
 	return k.portKeeper.BindPort(ctx, portID)
 }
 
 // GetChannel wraps IBC ChannelKeeper's GetChannel function.
-func (k Keeper) GetChannel(ctx sdk.Context, portID, channelID string) (channeltypes.Channel, bool) {
+func (k *Keeper) GetChannel(ctx sdk.Context, portID, channelID string) (channeltypes.Channel, bool) {
 	return k.channelKeeper.GetChannel(ctx, portID, channelID)
 }
 
 // GetPacketCommitment wraps IBC ChannelKeeper's GetPacketCommitment function.
-func (k Keeper) GetPacketCommitment(ctx sdk.Context, portID, channelID string, sequence uint64) []byte {
+func (k *Keeper) GetPacketCommitment(ctx sdk.Context, portID, channelID string, sequence uint64) []byte {
 	return k.channelKeeper.GetPacketCommitment(ctx, portID, channelID, sequence)
 }
 
 // GetNextSequenceSend wraps IBC ChannelKeeper's GetNextSequenceSend function.
-func (k Keeper) GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool) {
+func (k *Keeper) GetNextSequenceSend(ctx sdk.Context, portID, channelID string) (uint64, bool) {
 	return k.channelKeeper.GetNextSequenceSend(ctx, portID, channelID)
 }
 
 // SendPacket wraps IBC ChannelKeeper's SendPacket function
-func (k Keeper) SendPacket(ctx sdk.Context, chanCap *capabilitytypes.Capability, packet ibcexported.PacketI) error {
+func (k *Keeper) SendPacket(ctx sdk.Context, chanCap *capabilitytypes.Capability, packet ibcexported.PacketI) error {
 	return k.ics4Wrapper.SendPacket(ctx, chanCap, packet)
 }
 
 // WriteAcknowledgement wraps IBC ChannelKeeper's WriteAcknowledgement function.
 // ICS29 WriteAcknowledgement is used for asynchronous acknowledgements.
-func (k Keeper) WriteAcknowledgement(ctx sdk.Context, chanCap *capabilitytypes.Capability, packet ibcexported.PacketI, acknowledgement ibcexported.Acknowledgement) error {
+func (k *Keeper) WriteAcknowledgement(ctx sdk.Context, chanCap *capabilitytypes.Capability, packet ibcexported.PacketI, acknowledgement ibcexported.Acknowledgement) error {
 	return k.ics4Wrapper.WriteAcknowledgement(ctx, chanCap, packet, acknowledgement)
 }
 
-func (k Keeper) LookupModuleByChannel(ctx sdk.Context, portID, channelID string) (string, *capabilitytypes.Capability, error) {
+func (k *Keeper) LookupModuleByChannel(ctx sdk.Context, portID, channelID string) (string, *capabilitytypes.Capability, error) {
 	return k.channelKeeper.LookupModuleByChannel(ctx, portID, channelID)
 }
 

--- a/router/module.go
+++ b/router/module.go
@@ -78,11 +78,11 @@ func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 // AppModule represents the AppModule for this module
 type AppModule struct {
 	AppModuleBasic
-	keeper keeper.Keeper
+	keeper *keeper.Keeper
 }
 
 // NewAppModule creates a new router module
-func NewAppModule(k keeper.Keeper) AppModule {
+func NewAppModule(k *keeper.Keeper) AppModule {
 	return AppModule{
 		keeper: k,
 	}

--- a/test/setup.go
+++ b/test/setup.go
@@ -47,7 +47,7 @@ func NewTestSetup(t *testing.T, ctl *gomock.Controller) *TestSetup {
 
 		Keepers: &testKeepers{
 			ParamsKeeper: &paramsKeeper,
-			RouterKeeper: &routerKeeper,
+			RouterKeeper: routerKeeper,
 		},
 
 		Mocks: &testMocks{
@@ -135,7 +135,7 @@ func (i initializer) routerKeeper(
 	bankKeeper types.BankKeeper,
 	portKeeper types.PortKeeper,
 	ics4Wrapper porttypes.ICS4Wrapper,
-) keeper.Keeper {
+) *keeper.Keeper {
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	i.StateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, i.DB)
 
@@ -159,6 +159,6 @@ func (i initializer) routerModule(routerKeeper keeper.Keeper) router.AppModule {
 	return router.NewAppModule(routerKeeper)
 }
 
-func (i initializer) forwardMiddleware(app porttypes.IBCModule, k keeper.Keeper, retriesOnTimeout uint8, forwardTimeout time.Duration, refundTimeout time.Duration) router.IBCMiddleware {
+func (i initializer) forwardMiddleware(app porttypes.IBCModule, k *keeper.Keeper, retriesOnTimeout uint8, forwardTimeout time.Duration, refundTimeout time.Duration) router.IBCMiddleware {
 	return router.NewIBCMiddleware(app, k, retriesOnTimeout, forwardTimeout, refundTimeout)
 }


### PR DESCRIPTION
Change keeper impl to be pointer receiver. 
Add `SetTransferKeeper`

This allows more complex middleware wiring such as multiple middlewares with the callbacks in one direction and the ICS4 wrapper methods in the other direction. Example https://github.com/strangelove-ventures/juno/commit/06ee94176b1e8053f6e710c0ab5f64ceb6faad09