### PR TITLE
Accept JSON or JSON escaped string for next

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,25 +81,40 @@ Utilizing the packet `memo` field, instructions can be encoded as JSON for multi
 
 In the case of a timeout after 10 minutes for either forward, the packet would be retried up to 2 times, at which case an error ack would be written to issue a refund on the prior chain.
 
-`next` is a string since it could be any `memo` for the next hop, so it must be an escaped JSON string.
+`next` is the `memo` to pass for the next transfer hop. Per `memo` intended usage of a JSON string, it should be either JSON which will be Marshaled retaining key order, or an escaped JSON string which will be passed directly.
 
+`next` as JSON
 ```
 {
   "forward": {
     "receiver": "chain-c-bech32-address",
     "port": "transfer",
-    "channel": "channel-123"
+    "channel": "channel-123",
     "timeout": "10m",
-    "retries: 2,
-    "next" : "\{
-      \"forward\":\{
-        \"receiver\":\"chain-d-bech32-address\",
-        \"port\":\"transfer\",
-        \"channel\":\"channel-234\",
-        \"timeout\":\"10m\",
-        \"retries\":2
-      \}
-    \}"
+    "retries": 2,
+    "next": {
+      "forward": {
+        "receiver": "chain-d-bech32-address",
+        "port": "transfer",
+        "channel":"channel-234",
+        "timeout":"10m",
+        "retries": 2
+      }
+    }
+  }
+}
+```
+
+`next` as escaped JSON string
+```
+{
+  "forward": {
+    "receiver": "chain-c-bech32-address",
+    "port": "transfer",
+    "channel": "channel-123",
+    "timeout": "10m",
+    "retries": 2,
+    "next": "{\"forward\":{\"receiver\":\"chain-d-bech32-address\",\"port\":\"transfer\",\"channel\":\"channel-234\",\"timeout\":\"10m\",\"retries\":2}}"
   }
 }
 ```

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/iancoleman/orderedmap v0.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	github.com/tendermint/tendermint v0.34.24

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 h1:aSVUgRRRtOrZOC1fYmY9gV0e9z/Iu+xNVSASWjsuyGU=
 github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3/go.mod h1:5PC6ZNPde8bBqU/ewGZig35+UIZtw9Ytxez8/q5ZyFE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
+github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/improbable-eng/grpc-web v0.15.0 h1:BN+7z6uNXZ1tQGcNAuaU1YjsLTApzkjt2tzCixLaUPQ=

--- a/router/keeper/keeper.go
+++ b/router/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -230,7 +231,14 @@ func (k *Keeper) ForwardTransferPacket(
 
 	// set memo for next transfer with next from this transfer.
 	if metadata.Next != nil {
-		memo = *metadata.Next
+		memoBz, err := json.Marshal(metadata.Next)
+		if err != nil {
+			k.Logger(ctx).Error("packetForwardMiddleware error marshaling next as JSON",
+				"error", err,
+			)
+			return sdkerrors.Wrapf(sdkerrors.ErrJSONMarshal, err.Error())
+		}
+		memo = string(memoBz)
 	}
 
 	msgTransfer := transfertypes.NewMsgTransfer(
@@ -356,7 +364,9 @@ func (k *Keeper) RetryTimeout(
 	}
 
 	if data.Memo != "" {
-		metadata.Next = &data.Memo
+		if err := json.Unmarshal([]byte(data.Memo), metadata.Next); err != nil {
+			return fmt.Errorf("error unmarshaling memo json: %w", err)
+		}
 	}
 
 	amount, ok := sdk.NewIntFromString(data.Amount)

--- a/router/module.go
+++ b/router/module.go
@@ -62,7 +62,7 @@ func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Rout
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the ibc-router module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	_ = types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
 }
 
 // GetTxCmd implements AppModuleBasic interface

--- a/router/types/forward.go
+++ b/router/types/forward.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	host "github.com/cosmos/ibc-go/v6/modules/core/24-host"
+	"github.com/iancoleman/orderedmap"
 )
 
 type PacketMetadata struct {
@@ -17,7 +18,10 @@ type ForwardMetadata struct {
 	Channel  string        `json:"channel,omitempty"`
 	Timeout  time.Duration `json:"timeout,omitempty"`
 	Retries  *uint8        `json:"retries,omitempty"`
-	Next     *string       `json:"next,omitempty"`
+
+	// Using JSONObject so that objects for next property will not be mutated by golang's lexicographic key sort on map keys during Marshal.
+	// Supports primitives for Unmarshal/Marshal so that an escaped JSON-marshaled string is also valid.
+	Next *JSONObject `json:"next,omitempty"`
 }
 
 func (m *ForwardMetadata) Validate() error {
@@ -32,4 +36,46 @@ func (m *ForwardMetadata) Validate() error {
 	}
 
 	return nil
+}
+
+// JSONObject is a wrapper type to allow either a primitive type or a JSON object.
+// In the case the value is a JSON object, OrderedMap type is used so that key order
+// is retained across Unmarshal/Marshal.
+type JSONObject struct {
+	obj        bool
+	primitive  []byte
+	orderedMap orderedmap.OrderedMap
+}
+
+// NewJSONObject is a constructor used for tests.
+// The usage of JSONObject in the middleware is only json Marshal/Unmarshal
+func NewJSONObject(object bool, primitive []byte, orderedMap orderedmap.OrderedMap) *JSONObject {
+	return &JSONObject{
+		obj:        object,
+		primitive:  primitive,
+		orderedMap: orderedMap,
+	}
+}
+
+// UnmarshalJSON overrides the default json.Unmarshal behavior
+func (o *JSONObject) UnmarshalJSON(b []byte) error {
+	if err := o.orderedMap.UnmarshalJSON(b); err != nil {
+		// If ordered map unmarshal fails, this is a primitive value
+		o.obj = false
+		o.primitive = b
+		return nil
+	}
+	// This is a JSON object, now stored as an ordered map to retain key order.
+	o.obj = true
+	return nil
+}
+
+// MarshalJSON overrides the default json.Marshal behavior
+func (o JSONObject) MarshalJSON() ([]byte, error) {
+	if o.obj {
+		// non-primitive, return marshaled ordered map.
+		return o.orderedMap.MarshalJSON()
+	}
+	// primitive, return raw bytes.
+	return o.primitive, nil
 }

--- a/test/setup.go
+++ b/test/setup.go
@@ -148,10 +148,6 @@ func (i initializer) routerKeeper(
 	return routerKeeper
 }
 
-func (i initializer) routerModule(routerKeeper *keeper.Keeper) router.AppModule {
-	return router.NewAppModule(routerKeeper)
-}
-
 func (i initializer) forwardMiddleware(app porttypes.IBCModule, k *keeper.Keeper, retriesOnTimeout uint8, forwardTimeout time.Duration, refundTimeout time.Duration) router.IBCMiddleware {
 	return router.NewIBCMiddleware(app, k, retriesOnTimeout, forwardTimeout, refundTimeout)
 }


### PR DESCRIPTION
Modifies `next` property handling to accept either a JSON object which will be marshaled for the next `memo`, or the current expected string.

Introduces `OrderedMap` in order to ensure the JSON does not get rearranged by keys lexicographically during `json.Marshal` when the JSON object option is used. Without this, the next memo may not match the expectations, which makes testing high level `MsgTransfer` equality impossible since the `memo` strings would not match even though the JSON values are the same, only key order is different in the marshaled string.

Resolves #62 