### PR TITLE
Fix string unmarshal

### DIFF
--- a/router/types/forward.go
+++ b/router/types/forward.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -62,7 +63,13 @@ func (o *JSONObject) UnmarshalJSON(b []byte) error {
 	if err := o.orderedMap.UnmarshalJSON(b); err != nil {
 		// If ordered map unmarshal fails, this is a primitive value
 		o.obj = false
-		o.primitive = b
+		// Attempt to unmarshal as string, this removes extra JSON escaping
+		var primitiveStr string
+		if err := json.Unmarshal(b, &primitiveStr); err != nil {
+			o.primitive = b
+			return nil
+		}
+		o.primitive = []byte(primitiveStr)
 		return nil
 	}
 	// This is a JSON object, now stored as an ordered map to retain key order.

--- a/router/types/forward_test.go
+++ b/router/types/forward_test.go
@@ -1,0 +1,33 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/strangelove-ventures/packet-forward-middleware/v6/router/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardMetadataUnmarshalStringNext(t *testing.T) {
+	const memo = "{\"forward\":{\"receiver\":\"noble1f4cur2krsua2th9kkp7n0zje4stea4p9tu70u8\",\"port\":\"transfer\",\"channel\":\"channel-0\",\"timeout\":0,\"next\":\"{\\\"forward\\\":{\\\"receiver\\\":\\\"noble1l505zhahp24v5jsmps9vs5asah759fdce06sfp\\\",\\\"port\\\":\\\"transfer\\\",\\\"channel\\\":\\\"channel-0\\\",\\\"timeout\\\":0}}\"}}"
+	var packetMetadata types.PacketMetadata
+
+	err := json.Unmarshal([]byte(memo), &packetMetadata)
+	require.NoError(t, err)
+
+	nextBz, err := json.Marshal(packetMetadata.Forward.Next)
+	require.NoError(t, err)
+	require.Equal(t, `{"forward":{"receiver":"noble1l505zhahp24v5jsmps9vs5asah759fdce06sfp","port":"transfer","channel":"channel-0","timeout":0}}`, string(nextBz))
+}
+
+func TestForwardMetadataUnmarshalJSONNext(t *testing.T) {
+	const memo = "{\"forward\":{\"receiver\":\"noble1f4cur2krsua2th9kkp7n0zje4stea4p9tu70u8\",\"port\":\"transfer\",\"channel\":\"channel-0\",\"timeout\":0,\"next\":{\"forward\":{\"receiver\":\"noble1l505zhahp24v5jsmps9vs5asah759fdce06sfp\",\"port\":\"transfer\",\"channel\":\"channel-0\",\"timeout\":0}}}}"
+	var packetMetadata types.PacketMetadata
+
+	err := json.Unmarshal([]byte(memo), &packetMetadata)
+	require.NoError(t, err)
+
+	nextBz, err := json.Marshal(packetMetadata.Forward.Next)
+	require.NoError(t, err)
+	require.Equal(t, `{"forward":{"receiver":"noble1l505zhahp24v5jsmps9vs5asah759fdce06sfp","port":"transfer","channel":"channel-0","timeout":0}}`, string(nextBz))
+}


### PR DESCRIPTION
Without attempting to Unmarshal the`next` value as string, JSON strings (instead of objects) would have an extra level of escape characters. For more than one hop, this leads to packet forward middleware on the next chain being unable to unmarshal the `memo` and identify that it should be forwarded again.

Adds test case coverage