### PR TITLE
Fix: Allows timeout field to accept both uint64 and string durations

### DIFF
--- a/router/ibc_middleware.go
+++ b/router/ibc_middleware.go
@@ -140,7 +140,7 @@ func (im IBCMiddleware) OnRecvPacket(
 
 	d := make(map[string]interface{})
 	err := json.Unmarshal([]byte(data.Memo), &d)
-	if err != nil || d["forward"] == "" {
+	if err != nil || d["forward"] == nil {
 		// not a packet that should be forwarded
 		im.keeper.Logger(ctx).Debug("packetForwardMiddleware OnRecvPacket forward metadata does not exist")
 		return im.app.OnRecvPacket(ctx, packet, relayer)

--- a/router/ibc_middleware.go
+++ b/router/ibc_middleware.go
@@ -135,7 +135,7 @@ func (im IBCMiddleware) OnRecvPacket(
 		"sequence", packet.Sequence,
 		"src-channel", packet.SourceChannel, "src-port", packet.SourcePort,
 		"dst-channel", packet.DestinationChannel, "dst-port", packet.DestinationPort,
-		"amount", data.Amount, "denom", data.Denom,
+		"amount", data.Amount, "denom", data.Denom, "memo", data.Memo,
 	)
 
 	d := make(map[string]interface{})

--- a/router/ibc_middleware.go
+++ b/router/ibc_middleware.go
@@ -202,10 +202,9 @@ func (im IBCMiddleware) OnRecvPacket(
 
 	token := sdk.NewCoin(denomOnThisChain, amountInt)
 
-	var timeout time.Duration
-	if metadata.Timeout.Nanoseconds() > 0 {
-		timeout = metadata.Timeout
-	} else {
+	timeout := time.Duration(metadata.Timeout)
+
+	if timeout.Nanoseconds() <= 0 {
 		timeout = im.forwardTimeout
 	}
 

--- a/router/types/forward.go
+++ b/router/types/forward.go
@@ -91,7 +91,7 @@ func (o JSONObject) MarshalJSON() ([]byte, error) {
 }
 
 func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Duration(d).String())
+	return json.Marshal(time.Duration(d).Nanoseconds())
 }
 
 func (d *Duration) UnmarshalJSON(b []byte) error {

--- a/router/types/forward.go
+++ b/router/types/forward.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,16 +15,18 @@ type PacketMetadata struct {
 }
 
 type ForwardMetadata struct {
-	Receiver string        `json:"receiver,omitempty"`
-	Port     string        `json:"port,omitempty"`
-	Channel  string        `json:"channel,omitempty"`
-	Timeout  time.Duration `json:"timeout,omitempty"`
-	Retries  *uint8        `json:"retries,omitempty"`
+	Receiver string   `json:"receiver,omitempty"`
+	Port     string   `json:"port,omitempty"`
+	Channel  string   `json:"channel,omitempty"`
+	Timeout  Duration `json:"timeout,omitempty"`
+	Retries  *uint8   `json:"retries,omitempty"`
 
 	// Using JSONObject so that objects for next property will not be mutated by golang's lexicographic key sort on map keys during Marshal.
 	// Supports primitives for Unmarshal/Marshal so that an escaped JSON-marshaled string is also valid.
 	Next *JSONObject `json:"next,omitempty"`
 }
+
+type Duration time.Duration
 
 func (m *ForwardMetadata) Validate() error {
 	if m.Receiver == "" {
@@ -85,4 +88,29 @@ func (o JSONObject) MarshalJSON() ([]byte, error) {
 	}
 	// primitive, return raw bytes.
 	return o.primitive, nil
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		*d = Duration(time.Duration(value))
+		return nil
+	case string:
+		tmp, err := time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		*d = Duration(tmp)
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
 }

--- a/router/types/forward_test.go
+++ b/router/types/forward_test.go
@@ -31,3 +31,29 @@ func TestForwardMetadataUnmarshalJSONNext(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, `{"forward":{"receiver":"noble1l505zhahp24v5jsmps9vs5asah759fdce06sfp","port":"transfer","channel":"channel-0","timeout":0}}`, string(nextBz))
 }
+
+func TestTimeoutUnmarshalString(t *testing.T) {
+	const memo = "{\"forward\":{\"receiver\":\"noble1f4cur2krsua2th9kkp7n0zje4stea4p9tu70u8\",\"port\":\"transfer\",\"channel\":\"channel-0\",\"timeout\":\"60s\"}}"
+	var packetMetadata types.PacketMetadata
+
+	err := json.Unmarshal([]byte(memo), &packetMetadata)
+	require.NoError(t, err)
+
+	timeoutBz, err := json.Marshal(packetMetadata.Forward.Timeout)
+	require.NoError(t, err)
+
+	require.Equal(t, "\"1m0s\"", string(timeoutBz))
+}
+
+func TestTimeoutUnmarshalJSON(t *testing.T) {
+	const memo = "{\"forward\":{\"receiver\":\"noble1f4cur2krsua2th9kkp7n0zje4stea4p9tu70u8\",\"port\":\"transfer\",\"channel\":\"channel-0\",\"timeout\": 60000000000}}"
+	var packetMetadata types.PacketMetadata
+
+	err := json.Unmarshal([]byte(memo), &packetMetadata)
+	require.NoError(t, err)
+
+	timeoutBz, err := json.Marshal(packetMetadata.Forward.Timeout)
+	require.NoError(t, err)
+
+	require.Equal(t, "\"1m0s\"", string(timeoutBz))
+}

--- a/router/types/forward_test.go
+++ b/router/types/forward_test.go
@@ -42,7 +42,7 @@ func TestTimeoutUnmarshalString(t *testing.T) {
 	timeoutBz, err := json.Marshal(packetMetadata.Forward.Timeout)
 	require.NoError(t, err)
 
-	require.Equal(t, "\"1m0s\"", string(timeoutBz))
+	require.Equal(t, "60000000000", string(timeoutBz))
 }
 
 func TestTimeoutUnmarshalJSON(t *testing.T) {
@@ -55,5 +55,5 @@ func TestTimeoutUnmarshalJSON(t *testing.T) {
 	timeoutBz, err := json.Marshal(packetMetadata.Forward.Timeout)
 	require.NoError(t, err)
 
-	require.Equal(t, "\"1m0s\"", string(timeoutBz))
+	require.Equal(t, "60000000000", string(timeoutBz))
 }


### PR DESCRIPTION
Currently, the `timeout` field only works with time.duration types. So the example in the readme of using a time out of `\"timeout\":\"10m\"` does not work and causes the asset to get stuck on the middle chain.

Currently, if you want a 10 minute timeout you need to convert it to nanoseconds: `\"timeout\": 600000000000`.

This fixes the issue and allows users to use either a nanosecond uint64 OR a string format. 

I've also confirmed this works using an interchaintest test case on noble chain. See lines [632](https://github.com/strangelove-ventures/noble/blob/6c1ad20626933edad3703d86a8fe6ae675b2395c/interchaintest/packet_forward_test.go#L632)
and [688](https://github.com/strangelove-ventures/noble/blob/6c1ad20626933edad3703d86a8fe6ae675b2395c/interchaintest/packet_forward_test.go#L688) for both a uint64 version and a string version.

Once accepted, I can backport to v4, v5, v6, and main.


